### PR TITLE
Remove duplicate material merge call in FBX importer

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -729,9 +729,8 @@ def import_fbx(context, fbx_file_path):
         # Join Mesh objects separately for each vehicle
         join_mesh_objects_per_vehicle(vehicle_names)    
 
-        #Replace duplicate materials
+        # Replace duplicate materials
         merge_duplicate_materials_per_vehicle(vehicle_names)
-        merge_duplicate_materials_per_vehicle(vehicle_names)       
  
        # Restore the original frame rate settings
         context.scene.render.fps = original_fps


### PR DESCRIPTION
## Summary
- Remove redundant `merge_duplicate_materials_per_vehicle` invocation so materials are merged once per import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb062146048321926ea1d4c77e8578