### PR TITLE
Deduplicate vehicle IDs and anchor vehicle membership checks

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -30,8 +30,11 @@ def get_root_vehicle_names(imported_objects):
 
 
 def belongs_to_vehicle(obj_name: str, vehicle_name: str) -> bool:
-    """Check whether an object's name belongs to a specific vehicle."""
-    pattern = rf"(^|:)\s*{re.escape(vehicle_name)}($|:)"
+    """Check whether an object's name belongs to a specific vehicle.
+
+    Matches segments like "Heil" or "Heil.001" between colon delimiters.
+    """
+    pattern = rf"(^|:)\s*{re.escape(vehicle_name)}(?:\.\d+)?($|:)"
     return re.search(pattern, obj_name) is not None
 
 def offset_selected_animation(obj, frame_offset=-1):

--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -26,9 +26,10 @@ class Obj:
 
 def test_get_root_vehicle_names_dedup():
     root1 = Obj('Heil')
-    root2 = Obj('Heil_Rear')
-    child = Obj('Mesh: Heil: Body', type='MESH', parent=root1)
-    objects = [root1, root2, child]
+    root2 = Obj('Heil.001')
+    root3 = Obj('Heil_Rear')
+    child = Obj('Mesh: Heil.001: Body', type='MESH', parent=root2)
+    objects = [root1, root2, root3, child]
     assert get_root_vehicle_names(objects) == ['Heil', 'Heil_Rear']
 
 
@@ -38,8 +39,13 @@ def test_belongs_to_vehicle_match():
     assert not belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
     assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil_Rear')
 
+def test_belongs_to_vehicle_numeric_suffix():
+    assert belongs_to_vehicle('Mesh: Heil.001: Body', 'Heil')
+    assert not belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil')
+
 
 if __name__ == "__main__":
     test_get_root_vehicle_names_dedup()
     test_belongs_to_vehicle_match()
+    test_belongs_to_vehicle_numeric_suffix()
     print("ok")

--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -1,0 +1,45 @@
+import ast
+import pathlib
+import re
+
+# Parse functions from fbx_importer.py without importing the module
+module_path = pathlib.Path(__file__).resolve().parents[1] / "fbx_importer.py"
+source = module_path.read_text()
+module_ast = ast.parse(source)
+ns = {'re': re}
+for node in module_ast.body:
+    if isinstance(node, ast.FunctionDef) and node.name in {"normalize_root_name", "get_root_vehicle_names", "belongs_to_vehicle"}:
+        code = compile(ast.Module([node], []), filename="<ast>", mode="exec")
+        exec(code, ns)
+
+normalize_root_name = ns["normalize_root_name"]
+get_root_vehicle_names = ns["get_root_vehicle_names"]
+belongs_to_vehicle = ns["belongs_to_vehicle"]
+
+
+class Obj:
+    def __init__(self, name, type='EMPTY', parent=None):
+        self.name = name
+        self.type = type
+        self.parent = parent
+
+
+def test_get_root_vehicle_names_dedup():
+    root1 = Obj('Heil')
+    root2 = Obj('Heil_Rear')
+    child = Obj('Mesh: Heil: Body', type='MESH', parent=root1)
+    objects = [root1, root2, child]
+    assert get_root_vehicle_names(objects) == ['Heil', 'Heil_Rear']
+
+
+def test_belongs_to_vehicle_match():
+    assert belongs_to_vehicle('Mesh: Heil: Body', 'Heil')
+    assert belongs_to_vehicle('Heil', 'Heil')
+    assert not belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
+    assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil_Rear')
+
+
+if __name__ == "__main__":
+    test_get_root_vehicle_names_dedup()
+    test_belongs_to_vehicle_match()
+    print("ok")


### PR DESCRIPTION
## Summary
- Track only unique top-level empty names when collecting vehicles
- Add `belongs_to_vehicle` helper for exact/anchored name matching
- Use helper to keep joins, materials, and collections scoped per vehicle
- Add tests covering vehicle name extraction and matching

## Testing
- `python -m py_compile fbx_importer.py`
- `python tests/test_vehicle_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb06155d7c8321a6a87dfe907c032e