### PR TITLE
Handle removed Blender objects during FBX import

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -651,16 +651,22 @@ def import_fbx(context, fbx_file_path):
         include_keywords = ["Wheel"]
         
         # Loop through imported objects
-        for obj in imported_objects:        
+        for obj in imported_objects:
+            try:
+                name = obj.name
+            except ReferenceError:
+                # Object was removed (e.g. by copy_animated_rotation); skip it
+                continue
+
             # Condition: Name must contain at least one include keyword AND none of the exclude keywords
-            if any(kw in obj.name for kw in include_keywords) and not any(kw in obj.name for kw in exclude_keywords):
+            if any(kw in name for kw in include_keywords) and not any(kw in name for kw in exclude_keywords):
                 obj.select_set(True)  # Select the object
                 # Run the function
-                copy_animated_rotation(obj)  
+                copy_animated_rotation(obj)
 
-        # Rename all selected objects by adding "_FBX" to the end of their names 
-            if not obj.name.endswith(": FBX"):
-                obj.name += ": FBX"
+                # Rename the object by adding "_FBX" to the end of its name
+                if not name.endswith(": FBX"):
+                    obj.name = f"{name}: FBX"
 
         # Create the event collection
         event_collection_name = f"HVE: {filename}"


### PR DESCRIPTION
## Summary
- Skip deleted objects when filtering imported FBX objects
- Avoid errors by safely retrieving object names and renaming only valid objects

## Testing
- `pytest tests/test_vehicle_utils.py::test_get_root_vehicle_names_dedup -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_68bb2252058c8321b77faf9fcc57b631