### PR TITLE
Improve FBX rotation mapping and helper filtering

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -681,10 +681,13 @@ def import_fbx(context, fbx_file_path):
                 adjust_animation(obj)      
                 
                 
-        # List of keywords to exclude from selection
-        exclude_keywords = ["Steering", "Camber", "Rotation", "objects", "geometry"]  # Modify as needed     
-        include_keywords = ["Wheel"]
-        
+        # Derive keywords used for rotation helpers so they aren't processed as wheels
+        exclude_keywords = [
+            kw.lower() for kws in ROTATION_AXIS_KEYWORDS.values() for kw in kws
+        ]
+        exclude_keywords += ["objects", "geometry"]
+        include_keywords = ["wheel"]
+
         # Loop through imported objects
         for obj in imported_objects:
             try:
@@ -693,8 +696,12 @@ def import_fbx(context, fbx_file_path):
                 # Object was removed (e.g. by copy_animated_rotation); skip it
                 continue
 
+            name_lower = name.lower()
+
             # Condition: Name must contain at least one include keyword AND none of the exclude keywords
-            if any(kw in name for kw in include_keywords) and not any(kw in name for kw in exclude_keywords):
+            if any(kw in name_lower for kw in include_keywords) and not any(
+                kw in name_lower for kw in exclude_keywords
+            ):
                 obj.select_set(True)  # Select the object
                 # Run the function
                 copy_animated_rotation(obj)


### PR DESCRIPTION
## Summary
- Make rotation helper exclusion derive from `ROTATION_AXIS_KEYWORDS`
- Preserve existing axis mapping and skip missing rotation sources

## Testing
- `pytest tests/test_vehicle_utils.py::test_get_root_vehicle_names_dedup -q` *(fails: No module named 'bpy')*
- `pip install bpy --quiet` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2af94bfc832189006fc4dc98ae94