### PR TITLE
Allow partial vehicle name match

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -44,10 +44,12 @@ def get_root_vehicle_names(imported_objects):
 def belongs_to_vehicle(obj_name: str, vehicle_name: str) -> bool:
     """Check whether an object's name belongs to a specific vehicle.
 
-    Matches segments like "Heil" or "Heil.001" between colon delimiters.
+    The object's name is split on colon delimiters and any segment containing
+    ``vehicle_name`` is considered a match. This is more permissive than an
+    exact segment comparison so, for example, "Mesh: Heil_Rear: Body" will be
+    associated with the vehicle name ``"Heil"``.
     """
-    pattern = rf"(^|:)\s*{re.escape(vehicle_name)}(?:\.\d+)?($|:)"
-    return re.search(pattern, obj_name) is not None
+    return any(vehicle_name in segment for segment in obj_name.split(':'))
 
 def offset_selected_animation(obj, frame_offset=-1):
     """Offsets animation keyframes for all selected objects by the given frame amount."""

--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -36,12 +36,14 @@ def test_get_root_vehicle_names_dedup():
 def test_belongs_to_vehicle_match():
     assert belongs_to_vehicle('Mesh: Heil: Body', 'Heil')
     assert belongs_to_vehicle('Heil', 'Heil')
-    assert not belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
+    assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
     assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil_Rear')
+    assert not belongs_to_vehicle('Mesh: Other: Body', 'Heil')
 
 def test_belongs_to_vehicle_numeric_suffix():
     assert belongs_to_vehicle('Mesh: Heil.001: Body', 'Heil')
-    assert not belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil')
+    assert belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil')
+    assert not belongs_to_vehicle('Mesh: Other.001: Body', 'Heil')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- broaden vehicle ownership check to match on colon-separated segments containing the vehicle name
- update tests for new belongs_to_vehicle behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f77ae508321afdd5e0a62b8094d