### PR TITLE
enforce exact vehicle name segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ by editing `ROTATION_AXIS_KEYWORDS` in `fbx_importer.py` or by passing your own
 mapping when calling `copy_animated_rotation`. Any missing axes are skipped
 during import, so the helper objects are optional.
 
+## Migration Notes
+
+### `belongs_to_vehicle` name matching
+
+The helper function `belongs_to_vehicle` now matches vehicle names more
+strictly. Instead of treating any colon-delimited segment containing the target
+vehicle name as a match, each segment must *exactly* equal the vehicle name once
+numeric suffixes like `.001` are removed. For example, `"Heil_Rear"` will no
+longer match the vehicle `"Heil"`. Users who relied on the previous permissive
+behavior may need to adjust object naming conventions accordingly.
+
 ## Contribution Guidelines
 Contributions are welcome! To propose changes:
 1. Fork the repository and create a feature branch.

--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -42,14 +42,19 @@ def get_root_vehicle_names(imported_objects):
 
 
 def belongs_to_vehicle(obj_name: str, vehicle_name: str) -> bool:
-    """Check whether an object's name belongs to a specific vehicle.
+    """Return ``True`` if ``obj_name`` belongs to ``vehicle_name``.
 
-    The object's name is split on colon delimiters and any segment containing
-    ``vehicle_name`` is considered a match. This is more permissive than an
-    exact segment comparison so, for example, "Mesh: Heil_Rear: Body" will be
-    associated with the vehicle name ``"Heil"``.
+    The name is split on colon (``":"``) delimiters and each segment is
+    *normalized* by stripping Blender's numeric suffixes (e.g., ``.001``). A
+    match occurs only when a normalized segment exactly equals
+    ``vehicle_name``.
     """
-    return any(vehicle_name in segment for segment in obj_name.split(':'))
+
+    for segment in obj_name.split(":"):
+        normalized = re.sub(r"\.\d+$", "", segment).strip()
+        if normalized == vehicle_name:
+            return True
+    return False
 
 def offset_selected_animation(obj, frame_offset=-1):
     """Offsets animation keyframes for all selected objects by the given frame amount."""

--- a/tests/test_material_merge.py
+++ b/tests/test_material_merge.py
@@ -2,11 +2,12 @@ import ast
 import math
 import pathlib
 import types
+import re
 
 module_path = pathlib.Path(__file__).resolve().parents[1] / "fbx_importer.py"
 source = module_path.read_text()
 module_ast = ast.parse(source)
-ns = {"math": math}
+ns = {"math": math, "re": re}
 for node in module_ast.body:
     if isinstance(node, ast.FunctionDef) and node.name in {
         "materials_are_equal",

--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -42,13 +42,18 @@ def test_get_root_vehicle_names_dedup():
 def test_belongs_to_vehicle_match():
     assert belongs_to_vehicle('Mesh: Heil: Body', 'Heil')
     assert belongs_to_vehicle('Heil', 'Heil')
-    assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
     assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil_Rear')
     assert not belongs_to_vehicle('Mesh: Other: Body', 'Heil')
 
+
+def test_belongs_to_vehicle_distinct_prefixes():
+    assert not belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
+    assert not belongs_to_vehicle('Mesh: Heil: Body', 'Heil_Rear')
+
 def test_belongs_to_vehicle_numeric_suffix():
     assert belongs_to_vehicle('Mesh: Heil.001: Body', 'Heil')
-    assert belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil')
+    assert belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil_Rear')
+    assert not belongs_to_vehicle('Mesh: Heil_Rear.001: Body', 'Heil')
     assert not belongs_to_vehicle('Mesh: Other.001: Body', 'Heil')
 
 
@@ -63,9 +68,9 @@ def test_join_mesh_objects_per_vehicle_with_colon_segments():
             self.selected = val
 
     objs = [
-        Obj('Mesh:0 Honda'),
-        Obj('Mesh:1 Honda'),
-        Obj('Mesh:0 Toyota'),
+        Obj('Mesh: Honda:0'),
+        Obj('Mesh: Honda:1'),
+        Obj('Mesh: Toyota:0'),
     ]
 
     joined = []
@@ -113,7 +118,7 @@ def test_join_mesh_objects_per_vehicle_with_colon_segments():
     join_mesh_objects_per_vehicle(['Honda'])
 
     assert len(joined) == 1
-    assert {o.name for o in joined[0]} == {'Mesh:0 Honda', 'Mesh:1 Honda'}
+    assert {o.name for o in joined[0]} == {'Mesh: Honda:0', 'Mesh: Honda:1'}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tighten `belongs_to_vehicle` so only exact colon-delimited segments match a vehicle after stripping Blender numeric suffixes
- revise vehicle detection tests to keep similarly prefixed vehicles separate
- document stricter name matching in migration notes

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4487bfcc8321b32a0b7a574f9a50