### PR TITLE
Use parent collection for FBX subcollection assignment

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -220,6 +220,13 @@ def remove_from_all_collections(obj):
     for collection in list(obj.users_collection):
         collection.objects.unlink(obj)
 
+    # The scene's master collection is not included in ``obj.users_collection``,
+    # so explicitly unlink from it as well to ensure the object is fully
+    # detached before relinking.
+    active_root = bpy.context.scene.collection
+    if obj.name in active_root.objects:
+        active_root.objects.unlink(obj)
+
 def assign_objects_to_subcollection(collection_name, parent_collection, objects):
     """
     Create a subcollection under the given parent collection and assign objects to it.
@@ -825,11 +832,11 @@ def import_fbx(context, fbx_file_path):
                 if ("Wheel" in obj.name and belongs_to_vehicle(obj.name, vehicle_name)):
                     obj.select_set(True)  # Select the object
                     # Run the function
-                    assign_objects_to_subcollection(wheels_collection_name, vehicle_name,obj)
+                    assign_objects_to_subcollection(wheels_collection_name, fbx_collection, obj)
                 if ("Mesh" in obj.name and belongs_to_vehicle(obj.name, vehicle_name)):
                     obj.select_set(True)  # Select the object
                     # Run the function
-                    assign_objects_to_subcollection(mesh_collection_name, vehicle_name,obj)
+                    assign_objects_to_subcollection(mesh_collection_name, fbx_collection, obj)
             
             target_name = vehicle_name + ": FBX"  # Original name pattern
             new_name = f"CG: {vehicle_name} {filename}: FBX"  # New name pattern

--- a/variableoutput_importer.py
+++ b/variableoutput_importer.py
@@ -10,11 +10,19 @@ bl_info = {
     "blender": (3, 1, 0),
 }
 def remove_from_all_collections(obj):
-    """ Remove an object from all Blender collections before reassigning it. """
-    if obj and obj.name in bpy.data.objects:
-        for collection in bpy.data.collections:
-            if obj.name in collection.objects:
-                collection.objects.unlink(obj)
+    """Remove an object from all Blender collections before reassigning it."""
+    if not obj or obj.name not in bpy.data.objects:
+        return
+
+    # Unlink from all user collections
+    for collection in list(obj.users_collection):
+        collection.objects.unlink(obj)
+
+    # Also unlink from the scene's master collection, which isn't included in
+    # ``obj.users_collection`` or ``bpy.data.collections``.
+    active_root = bpy.context.scene.collection
+    if obj.name in active_root.objects:
+        active_root.objects.unlink(obj)
 
 def assign_objects_to_subcollection(collection_name, parent_collection, objects):
     """
@@ -878,9 +886,13 @@ def add_vehicle(context, vehicle_name, vehicles, scale_factor, numframes, name_m
     
     # Function to remove an object from all collections before reassigning
     def remove_from_all_collections(obj):
-        """ Remove an object from all Blender collections before reassigning it. """
-        for collection in obj.users_collection:
+        """Remove an object from all Blender collections before reassigning it."""
+        for collection in list(obj.users_collection):
             collection.objects.unlink(obj)
+
+        active_root = bpy.context.scene.collection
+        if obj.name in active_root.objects:
+            active_root.objects.unlink(obj)
 
     # Get all vehicle data (not just kinematic)
     vehicle_data = vehicles[vehicle_name]  # Now includes everything


### PR DESCRIPTION
## Summary
- assign wheel and mesh objects to subcollections under the FBX collection
- ensure objects are fully unlinked from the scene collection before relinking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc32bf8f88321ad2521ee919b6e83