### PR TITLE
Improve vehicle name matching

### DIFF
--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -43,12 +43,14 @@ def test_belongs_to_vehicle_match():
     assert belongs_to_vehicle('Mesh: Heil: Body', 'Heil')
     assert belongs_to_vehicle('Heil', 'Heil')
     assert belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil_Rear')
+    assert belongs_to_vehicle('Wheel: Heil Rear: Body', 'Heil_Rear')
     assert not belongs_to_vehicle('Mesh: Other: Body', 'Heil')
 
 
 def test_belongs_to_vehicle_distinct_prefixes():
     assert not belongs_to_vehicle('Mesh: Heil_Rear: Body', 'Heil')
     assert not belongs_to_vehicle('Mesh: Heil: Body', 'Heil_Rear')
+    assert not belongs_to_vehicle('Wheel: Heil Rear: Body', 'Heil')
 
 def test_belongs_to_vehicle_numeric_suffix():
     assert belongs_to_vehicle('Mesh: Heil.001: Body', 'Heil')


### PR DESCRIPTION
## Summary
- normalize object and vehicle names into tokens and match consecutive sequences
- expand unit tests for multi-word vehicle names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd3152a5483218151dfbfec310cca