### PR TITLE
Filter wheel helpers by vehicle

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -150,6 +150,7 @@ def copy_animated_rotation(parent, axis_keywords=None, debug=False):
     axis_keywords = axis_keywords or ROTATION_AXIS_KEYWORDS
 
     norm_parent = normalize_name(parent.name)
+    vehicle_id = parent.name.split(":")[-1].strip()
     if debug:
         print(f"🛠 Normalized parent name: '{norm_parent}'")
 
@@ -160,6 +161,7 @@ def copy_animated_rotation(parent, axis_keywords=None, debug=False):
         if obj != parent
         and norm_parent in normalize_name(obj.name)
         and "objects" in obj.name.lower()
+        and belongs_to_vehicle(obj.name, vehicle_id)
     ]
 
     if not selected_objects:
@@ -176,7 +178,9 @@ def copy_animated_rotation(parent, axis_keywords=None, debug=False):
     selected_objects = [
         obj
         for obj in bpy.context.selected_objects
-        if obj != parent and norm_parent in normalize_name(obj.name)
+        if obj != parent
+        and norm_parent in normalize_name(obj.name)
+        and belongs_to_vehicle(obj.name, vehicle_id)
     ]
     if debug:
         print(f"🛠 Candidate helper objects: {[obj.name for obj in selected_objects]}")
@@ -833,6 +837,7 @@ def import_fbx(context, fbx_file_path):
             if any(kw in name_lower for kw in include_keywords) and not any(
                 kw in name_lower for kw in exclude_keywords
             ):
+                bpy.ops.object.select_all(action="DESELECT")
                 obj.select_set(True)  # Select the object
                 # Run the function
                 copy_animated_rotation(obj, debug=True)

--- a/tests/test_vehicle_utils.py
+++ b/tests/test_vehicle_utils.py
@@ -141,7 +141,7 @@ def test_copy_animated_rotation_discovers_helpers_with_normalized_names():
     parent = Obj('Wheel_FL')
     parent.animation_data = Anim()
 
-    helper = Obj('Wheel FL Camber Objects')
+    helper = Obj('Wheel: Wheel_FL: Camber Objects')
     helper.animation_data = Anim()
 
     removed = []
@@ -163,6 +163,44 @@ def test_copy_animated_rotation_discovers_helpers_with_normalized_names():
     copy_animated_rotation(parent)
 
     assert removed == [helper]
+
+
+def test_copy_animated_rotation_filters_by_vehicle_id():
+    class Anim:
+        def __init__(self):
+            self.action = type('action', (), {'fcurves': []})()
+
+    parent = Obj('Wheel: Heil_Rear')
+    parent.animation_data = Anim()
+
+    rotation = Obj('Wheel: Heil_Rear: Rotation Objects')
+    rotation.animation_data = Anim()
+    camber = Obj('Wheel: Heil_Rear: Camber Objects')
+    camber.animation_data = Anim()
+    steering = Obj('Wheel: Heil_Rear: Steering Objects')
+    steering.animation_data = Anim()
+    other = Obj('Wheel: Other: Rotation Objects')
+    other.animation_data = Anim()
+
+    removed = []
+
+    class Objects:
+        def remove(self, obj, do_unlink=True):
+            removed.append(obj)
+
+    bpy_stub = type(
+        'bpy',
+        (),
+        {
+            'context': type('context', (), {'selected_objects': [parent, rotation, camber, steering, other]})(),
+            'data': type('data', (), {'objects': Objects()})(),
+        },
+    )()
+
+    ns.update({'bpy': bpy_stub})
+    copy_animated_rotation(parent)
+
+    assert set(removed) == {rotation, camber, steering}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- derive wheel vehicle identifier from final colon segment
- filter wheel helper candidates using `belongs_to_vehicle`
- clear Blender selection before processing each wheel
- add regression test ensuring helpers are restricted to matching vehicles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8dafbe1883219b6150a325ad8724