### PR TITLE
Include renamed wheel helpers in FBX collections

### DIFF
--- a/fbx_importer.py
+++ b/fbx_importer.py
@@ -646,10 +646,6 @@ def import_fbx(context, fbx_file_path):
         else:
             print(f"⏳ Timeline unchanged: Existing frame end ({current_max_frame}) is greater than or equal to imported max ({max_frame})")
 
-        # Determine root vehicle names from imported objects
-        vehicle_names = get_root_vehicle_names(imported_objects)
-
-                
                 
         # Define name replacements in sequential order
         name_replacements = {
@@ -869,6 +865,9 @@ def import_fbx(context, fbx_file_path):
                 # Rename the object by adding "_FBX" to the end of its name
                 if not name.endswith(": FBX"):
                     obj.name = f"{name}: FBX"
+
+        # Determine root vehicle names after any renaming or cleanup
+        vehicle_names = get_root_vehicle_names(imported_objects)
 
         # Create the event collection
         event_collection_name = f"HVE: {filename}"


### PR DESCRIPTION
## Summary
- Recompute vehicle names after any import-time renaming
- Ensure all newly imported objects, including Camber/Rotation empties, are linked to the correct FBX collection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd97b779e48321ba2359ea9d6f9578