### PR TITLE
Handle non-numeric timestamps explicitly

### DIFF
--- a/racerender_exporter.py
+++ b/racerender_exporter.py
@@ -32,7 +32,8 @@ def export_racerender(context, filepath, scale_factor=1.0):
             
             try:
                 time.append(float(row[0]))
-            except:
+            except ValueError:
+                # Handle non-numeric timestamps (e.g., header rows)
                 time.append(row[0])
             data.append(row[1:])
     #Set the frame rate

--- a/variableoutput_importer.py
+++ b/variableoutput_importer.py
@@ -143,7 +143,8 @@ def read_some_data(context, filepath, scale_factor, save_separate_csv):
             
             try:
                 time.append(float(row[0]))
-            except:
+            except ValueError:
+                # Handle non-numeric timestamps (e.g., header rows)
                 time.append(row[0])
             data.append(row[1:])
    


### PR DESCRIPTION
## Summary
- Restrict timestamp parsing error handling to ValueError in race render exporter
- Do the same ValueError-only handling in variable output importer so unexpected errors bubble up

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c23afacfd8832187905f9b5ac41284