### PR TITLE
Include ortho_projector in registration imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ try:
         racerender_exporter, racerender_exporter_ui,
         fbx_importer, fbx_importer_ui,
         motionpaths, xyz_importer, xyz_importer_ui,
-        edr_importer, scale_objects, import_xyzrpy,
+        edr_importer, scale_objects, import_xyzrpy, ortho_projector,
     )
 
     from bpy.props import *
@@ -39,7 +39,7 @@ try:
         ui, materials, prefs, ops, export_vehicle_ui, export_environment_ui,
         contacts_exporter_ui, variableoutput_importer_ui, racerender_exporter_ui,
         fbx_importer_ui, motionpaths, xyz_importer_ui, edr_importer, scale_objects,
-        import_xyzrpy,
+        import_xyzrpy, ortho_projector,
     ]
 
     # Aggregate all classes from modules


### PR DESCRIPTION
## Summary
- add ortho_projector to the addon import list so it is available during registration
- include ortho_projector in the aggregated modules list for class registration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf78a0c188321b2f07ed6970beafb