### PR TITLE
Update panel registration to include ortho projector panel

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -89,19 +89,22 @@ def sync_fps_with_scene(self, context):
         context.scene.anim_settings.anim_fps = context.scene.render.fps
         
 def update_panel_bl_category(self, context):
+    from . import ortho_projector
+
     main_panels = (HVE_PT_pre, HVE_PT_post)
     sub_panels = (
         HVE_PT_mechanist_setup,
         HVE_PT_mechanist_export,
-        HVE_PT_contacts_exporter,        
+        HVE_PT_contacts_exporter,
         HVE_PT_fbx_importer,
         HVE_PT_variableoutput_importer,
         HVE_PT_edr_importer,      
         HVE_PT_xyzrpy_importer,        
-        HVE_PT_point_importer,        
+        HVE_PT_point_importer,
         HVE_PT_motion_paths,
         HVE_PT_scale_objects,
         HVE_PT_race_render_exporter,
+        ortho_projector.HVE_PT_ortho_projector,
     )
     try:
         for p in main_panels:


### PR DESCRIPTION
## Summary
- import the ortho projector panel module within `update_panel_bl_category`
- include the ortho projector panel when re-registering UI sub panels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf79c89ec83219fd42ec3be7223ec