### PR TITLE
Move ortho projector panel under other tools

### DIFF
--- a/ortho_projector.py
+++ b/ortho_projector.py
@@ -275,7 +275,7 @@ class HVE_PT_ortho_projector(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = "HVE"
-    bl_parent_id = "HVE_PT_post"
+    bl_parent_id = "HVE_PT_other_tools"
 
     @classmethod
     def poll(cls, context: Context) -> bool:


### PR DESCRIPTION
## Summary
- update the Ortho Projector panel to use HVE_PT_other_tools as its parent so it appears in the Other Tools panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cafaca49188321886bb916436d42f4