### PR TITLE
Add class registry tuple for ortho projector module

### DIFF
--- a/ortho_projector.py
+++ b/ortho_projector.py
@@ -317,14 +317,21 @@ def menu_func(self, context):
     self.layout.operator(OBJECT_OT_project_ortho_bake.bl_idname, icon='RENDER_STILL')
 
 
+classes = (
+    OBJECT_OT_project_ortho_bake,
+)
+
+
 def register():
-    bpy.utils.register_class(OBJECT_OT_project_ortho_bake)
+    for cls in classes:
+        bpy.utils.register_class(cls)
     bpy.types.VIEW3D_MT_object.append(menu_func)
 
 
 def unregister():
     bpy.types.VIEW3D_MT_object.remove(menu_func)
-    bpy.utils.unregister_class(OBJECT_OT_project_ortho_bake)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a module-level `classes` tuple to expose the ortho projector operator
- register and unregister the operator by iterating through the tuple like other modules

## Testing
- python - <<'PY' (stubbed bpy + mathutils) to import `hve_tools.ortho_projector` and verify the `classes` tuple exists


------
https://chatgpt.com/codex/tasks/task_e_68cb04f236708321a7a9fd85e1478002